### PR TITLE
userpage: change unread link to read

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -9,7 +9,7 @@
 <h2 id=user></h2>
 </div>
 <a href=bookmarklet>Bookmarklet</a>
-<a href=# id=unread>Unread Articles</a>
+<a href=# id=read>Read Articles</a>
 <a href=help>Help</a>
 </header>
 <h3>Labels</h3>

--- a/userpage.js
+++ b/userpage.js
@@ -57,7 +57,7 @@ function get_feeds() {
 
 h2.innerHTML = user;
 document.title = user + ' (feedreader.co)';
-unread.href = "/" + user + "/feeds";
+read.href = "/" + user + "/labels/read";
 
 get_labels();
 get_folders();


### PR DESCRIPTION
This pr edited unread link to read articles. It is on the user page. Because the default page now is the unread articles so the link can be used for read articles instead. 