### PR TITLE
Handle errors when loading articles

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -65,14 +65,21 @@ function displayArticle(article) {
 
 function getArticle(id) {
   if (!id) return;
-  lib.articles.get(id).then(({ article, error }) => {
+  return lib.articles.get(id).then(({ article, error }) => {
     if (!article) {
       console.error(`Could not parse articles/${id}`, error);
     }
     if (!document.getElementById(id)) {
       displayArticle(article);
     }
-  }).catch(console.error);
+  });
+}
+
+function getNArticles(articles, n, i) {
+  if (i >= articles.length) return;
+  return getArticle(articles[i])
+    .then(() => getNArticles(articles, n - 1, i + 1),
+      () => getNArticles(articles, n, i + 1));
 }
 
 function getArticles() {
@@ -87,7 +94,7 @@ function getArticles() {
       if (i < 0) {
         i = 0;
       }
-      articles.slice(i, i + 4).forEach(getArticle);
+      getNArticles(articles, 5, i);
     }
   });
 }


### PR DESCRIPTION
getArticles() used to fetch the next five ids - if these requests failed (for instance if the article couldn't be found), that's it!
This PR doesn't count failed requests as part of those five :) 